### PR TITLE
[WIP] Recreate org and reassociate manager.

### DIFF
--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -12,6 +12,7 @@ type Options struct {
 	ClientID     string `envconfig:"client_id" required:"true"`
 	ClientSecret string `envconfig:"client_secret" required:"true"`
 	OrgName      string `envconfig:"org_name" required:"true"`
+	BotUser      string `envconfig:"bot_user" required:"true"`
 }
 
 func main() {
@@ -37,5 +38,15 @@ func main() {
 	err = client.DeleteOrg(org.Guid)
 	if err != nil {
 		log.Fatalf("error deleting org: %s", err.Error())
+	}
+
+	err = client.CreateOrg(opts.OrgName)
+	if err != nil {
+		log.Fatalf("error recreating org: %s", err.Error())
+	}
+
+	err = client.AssociateManagerByUsername(opts.BotUser)
+	if err != nil {
+		log.Fatalf("error adding orgmanager: %s", err.Error())
 	}
 }


### PR DESCRIPTION
So that we can skip org creation in https://github.com/18F/cg-sandbox-bot and drop the bot client permissions: https://github.com/18F/cg-sandbox-bot.

Depends on https://github.com/cloudfoundry-community/go-cfclient/pull/60, https://github.com/cloudfoundry-community/go-cfclient/pull/61.