### PR TITLE
Notify all users of the purge.

### DIFF
--- a/cmd/notify/main.go
+++ b/cmd/notify/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"net/main"
+	"net/mail"
 	"net/url"
 	"text/template"
 
@@ -14,65 +14,23 @@ import (
 )
 
 type Options struct {
-	APIAddress   string   `envconfig:"api_address" required:"true"`
-	ClientID     string   `envconfig:"client_id" required:"true"`
-	ClientSecret string   `envconfig:"client_secret" required:"true"`
-	OrgName      string   `envconfig:"org_name" required:"true"`
-	ServiceNames []string `envconfig:"service_names" required:"true"`
-	SMTPHost     string   `envconfig:"smtp_host" required:"true"`
-	SMTPPort     int      `envconfig:"smtp_port" default:"587"`
-	SMTPUser     string   `envconfig:"smtp_user" required:"true"`
-	SMTPPass     string   `envconfig:"smtp_pass" required:"true"`
-	MailSender   string   `envconfig:"mail_sender" required:"true"`
-	MailSubject  string   `envconfig:"mail_subject" required:"true"`
-}
-
-func getServiceByName(client *cfclient.Client, service string) (cfclient.Service, error) {
-	q := url.Values{}
-	q.Set("q", fmt.Sprintf("label:%s", service))
-	services, err := client.ListServicesByQuery(q)
-	if err != nil {
-		return cfclient.Service{}, err
-	}
-	if len(services) != 1 {
-		return cfclient.Service{}, fmt.Errorf("could not find service %s", service)
-	}
-	return services[0], nil
-}
-
-// listInstances gets a map from space guids to lists of relevant service instances
-func listInstances(client *cfclient.Client, orgGUID string, services map[string]bool) (map[string][]cfclient.ServiceInstance, error) {
-	q := url.Values{}
-	q.Set("q", fmt.Sprintf("organization_guid:%s", orgGUID))
-	instances, err := client.ListServiceInstancesByQuery(q)
-	m := map[string][]cfclient.ServiceInstance{}
-	if err != nil {
-		return m, err
-	}
-	for _, instance := range instances {
-		if _, ok := services[instance.ServiceGuid]; ok {
-			if _, ok := m[instance.SpaceGuid]; !ok {
-				m[instance.SpaceGuid] = []cfclient.ServiceInstance{}
-			}
-			m[instance.SpaceGuid] = append(m[instance.SpaceGuid], instance)
-		}
-	}
-	return m, nil
+	APIAddress   string `envconfig:"api_address" required:"true"`
+	ClientID     string `envconfig:"client_id" required:"true"`
+	ClientSecret string `envconfig:"client_secret" required:"true"`
+	OrgName      string `envconfig:"org_name" required:"true"`
+	SMTPHost     string `envconfig:"smtp_host" required:"true"`
+	SMTPPort     int    `envconfig:"smtp_port" default:"587"`
+	SMTPUser     string `envconfig:"smtp_user" required:"true"`
+	SMTPPass     string `envconfig:"smtp_pass" required:"true"`
+	MailSender   string `envconfig:"mail_sender" required:"true"`
+	MailSubject  string `envconfig:"mail_subject" required:"true"`
 }
 
 // listSpaces gets a map from space guids to spaces
-func listSpaces(client *cfclient.Client, orgGUID string) (map[string]cfclient.Space, error) {
+func listSpaces(client *cfclient.Client, orgGUID string) ([]cfclient.Space, error) {
 	q := url.Values{}
 	q.Set("q", fmt.Sprintf("organization_guid:%s", orgGUID))
-	spaces, err := client.ListSpacesByQuery(q)
-	if err != nil {
-		return nil, err
-	}
-	m := make(map[string]cfclient.Space, len(spaces))
-	for _, space := range spaces {
-		m[space.Guid] = space
-	}
-	return m, nil
+	return client.ListSpacesByQuery(q)
 }
 
 // listRecipients get a list of recipient emails from a space
@@ -93,14 +51,12 @@ func listRecipients(space cfclient.Space) ([]string, error) {
 func sendMail(
 	opts Options,
 	tmpl *template.Template,
-	instances []cfclient.ServiceInstance,
 	space cfclient.Space,
 	recipients []string,
 ) error {
 	b := bytes.Buffer{}
 	if err := tmpl.Execute(&b, map[string]interface{}{
-		"space":     space,
-		"instances": instances,
+		"space": space,
 	}); err != nil {
 		return err
 	}
@@ -148,34 +104,18 @@ func main() {
 		log.Fatalf("error getting org: %s", err.Error())
 	}
 
-	services := make(map[string]bool, len(opts.ServiceNames))
-	for _, label := range opts.ServiceNames {
-		service, err := getServiceByName(client, label)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-		services[service.Guid] = true
-	}
-
-	instances, err := listInstances(client, org.Guid, services)
-	if err != nil {
-		log.Fatalf("error listing instances: %s", err.Error())
-	}
-
 	spaces, err := listSpaces(client, org.Guid)
 	if err != nil {
 		log.Fatalf("error listing spaces: %s", err.Error())
 	}
 
-	for spaceGuid, instances := range instances {
-		if space, ok := spaces[spaceGuid]; ok {
-			recipients, err := listRecipients(space)
-			if err != nil {
-				log.Fatalf("error listing recipients", err.Error())
-			}
-			if err := sendMail(opts, tmpl, instances, space, recipients); err != nil {
-				log.Fatalf("error sending mail", err.Error())
-			}
+	for _, space := range spaces {
+		recipients, err := listRecipients(space)
+		if err != nil {
+			log.Fatalf("error listing recipients", err.Error())
+		}
+		if err := sendMail(opts, tmpl, space, recipients); err != nil {
+			log.Fatalf("error sending mail", err.Error())
 		}
 	}
 }

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -5,7 +5,6 @@ notify-api-url:
 notify-client-id:
 notify-client-secret:
 notify-org-name:
-notify-service-names:
 notify-smtp-host:
 notify-smtp-user:
 notify-smtp-pass:

--- a/email.tmpl
+++ b/email.tmpl
@@ -1,5 +1,1 @@
-Warning: space {{.space.Name}} will be deleted on the first of the month. The following service instances with persistent data will be deleted:
-
-{{range $instance := .instances -}}
-* {{$instance.Name -}}
-{{end}}
+Warning: space {{.space.Name}} will be deleted on the first of the month.

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -13,7 +13,6 @@ jobs:
       CLIENT_ID: {{notify-client-id}}
       CLIENT_SECRET: {{notify-client-secret}}
       ORG_NAME: {{notify-org-name}}
-      SERVICE_NAMES: {{notify-service-names}}
       SMTP_HOST: {{notify-smtp-host}}
       SMTP_USER: {{notify-smtp-user}}
       SMTP_PASS: {{notify-smtp-pass}}


### PR DESCRIPTION
Upon further discussion with @mogul, we're going to email *all* sandbox users about upcoming sandbox purges. This means we can delete a bunch of code that was used to figure out which sandbox spaces included stateful services.