### PR TITLE
Update template tests.

### DIFF
--- a/testdata/notify.html
+++ b/testdata/notify.html
@@ -18,7 +18,7 @@ Deleting the content of the sandbox resets the clock; you can start a new 90-day
 instance in the empty space.</p>
 
 <p>We hope you've found the sandbox helpful.
-If you'd like to host longer-lived content on cloud.gov, you'll need to do it as part of a <a href="https://cloud.gov/overview/pricing/rates/">prototyping or production package</a>.
+If you'd like to host longer-lived content on cloud.gov, you'll need to do it as part of a <a href="https://cloud.gov/pricing">prototyping or production package</a>.
 Please <a href="https://cloud.gov/docs/help/">contact us</a> to learn how to purchase one of these packages.</p>
 
 </body>

--- a/testdata/purge.html
+++ b/testdata/purge.html
@@ -17,7 +17,7 @@ This has reset the clock; you can start a new 90-day evaluation period just by c
 instance in the empty space.</p>
 
 <p>We hope you've found the sandbox helpful.
-If you'd like to host longer-lived content on cloud.gov, you'll need to do it as part of a <a href="https://cloud.gov/overview/pricing/rates/">prototyping or production package</a>.
+If you'd like to host longer-lived content on cloud.gov, you'll need to do it as part of a <a href="https://cloud.gov/pricing">prototyping or production package</a>.
 Please <a href="https://cloud.gov/docs/help/">contact us</a> to learn how to purchase one of these packages.</p>
 
 </body>


### PR DESCRIPTION
Because the tests check in exact template output. Alternatively, we could change the tests so that we don't have to do this every time templates change 🤔 