### PR TITLE
Skip users that no longer exist.

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -21,14 +21,15 @@ type SMTPOptions struct {
 	SMTPPass string `envconfig:"smtp_pass" required:"true"`
 }
 
-// ListRecipients get a list of recipient emails from a space
-func ListRecipients(space cfclient.Space) (addresses, developers, managers []string, err error) {
-	var roles []cfclient.SpaceRole
-	roles, err = space.Roles()
-	if err != nil {
-		return
-	}
+// ListRecipients get a list of recipient emails from space roles
+func ListRecipients(userGUIDs map[string]bool, roles []cfclient.SpaceRole) (addresses, developers, managers []string) {
+	addresses = []string{}
+	developers = []string{}
+	managers = []string{}
 	for _, role := range roles {
+		if _, ok := userGUIDs[role.Guid]; !ok {
+			continue
+		}
 		if _, err := mail.ParseAddress(role.Username); err == nil {
 			addresses = append(addresses, role.Username)
 		}
@@ -36,7 +37,7 @@ func ListRecipients(space cfclient.Space) (addresses, developers, managers []str
 			if roleType == "space_developer" {
 				developers = append(developers, role.Guid)
 			} else if roleType == "space_manager" {
-				developers = append(managers, role.Guid)
+				managers = append(managers, role.Guid)
 			}
 		}
 	}

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -15,6 +15,40 @@ import (
 )
 
 var _ = Describe("Sandbox", func() {
+	Describe("ListRecipients", func() {
+		var (
+			userGUIDs map[string]bool
+			roles     []cfclient.SpaceRole
+		)
+
+		It("skips users not in guids map", func() {
+			userGUIDs = map[string]bool{
+				"user-1": true,
+				"user-2": true,
+			}
+			roles = []cfclient.SpaceRole{
+				{Guid: "user-1", SpaceRoles: []string{"space_developer", "space_manager"}},
+				{Guid: "user-2", SpaceRoles: []string{"space_developer"}},
+				{Guid: "user-3", SpaceRoles: []string{"space_developer"}},
+			}
+			_, developers, managers := sandbox.ListRecipients(userGUIDs, roles)
+			Expect(developers).To(Equal([]string{"user-1", "user-2"}))
+			Expect(managers).To(Equal([]string{"user-1"}))
+		})
+
+		It("parses email addresses", func() {
+			userGUIDs = map[string]bool{
+				"user-1": true,
+			}
+			roles = []cfclient.SpaceRole{
+				{Guid: "user-1", SpaceRoles: []string{"space_developer"}, Username: "foo@bar.gov"},
+				{Guid: "user-2", SpaceRoles: []string{"space_manager"}},
+			}
+			addresses, _, _ := sandbox.ListRecipients(userGUIDs, roles)
+			Expect(addresses).To(Equal([]string{"foo@bar.gov"}))
+		})
+	})
+
 	Describe("ListPurgeSpaces", func() {
 		var (
 			spaces    []cfclient.Space


### PR DESCRIPTION
To avoid `InvalidRelation` errors on space recreate, prune users that
don't exist before recreate.

See https://ci.fr.cloud.gov/teams/main/pipelines/purge-sandboxes/jobs/purge-sandboxes-production/builds/130 for an example of the error we're trying to fix.