### PR TITLE
Adding in the necessary params;

### DIFF
--- a/ci/purge.yml
+++ b/ci/purge.yml
@@ -13,3 +13,21 @@ inputs:
 
 run:
   path: gopath/src/github.com/18F/cg-sandbox/ci/purge.sh
+
+params:
+  API_ADDRESS:
+  CLIENT_ID:
+  CLIENT_SECRET:
+  ORG_PREFIX:
+  NOTIFY_DAYS:
+  PURGE_DAYS:
+  NOTIFY_MAIL_SUBJECT:
+  PURGE_MAIL_SUBJECT:
+  SMTP_HOST:
+  SMTP_USER:
+  SMTP_PASS:
+  SMTP_PORT:
+  SMTP_CERT:
+  MAIL_SENDER:
+  TIME_STARTS_AT:
+  DRY_RUN:


### PR DESCRIPTION
Concourse will eventually make this an error, so this is so we're ahead
of the eventual update. Checkout the release notes for Concourse 4.1.0.

:eyes: https://concourse-ci.org/download.html#v410